### PR TITLE
Introduced New Command for Configuration File Management with Subcommands

### DIFF
--- a/cmd/mping/main.go
+++ b/cmd/mping/main.go
@@ -19,7 +19,10 @@ func Execute() {
 	cmd.Version = Version
 	cmd.Flags().BoolP("version", "v", false, "Display version")
 	cmd.SetVersionTemplate(fmt.Sprintf("mping, version: {{ .Version }} (revision: %s, goversion: %s)", Revision, GoVersion))
-	cmd.AddCommand(command.NewPingBatchCmd())
+	cmd.AddCommand(
+		command.NewPingBatchCmd(),
+		command.NewConfigCmd(),
+	)
 	cmd.CompletionOptions.HiddenDefaultCmd = true
 	cmd.SetOutput(os.Stdout)
 

--- a/internal/command/config.go
+++ b/internal/command/config.go
@@ -1,0 +1,52 @@
+package command
+
+import (
+	"github.com/servak/mping/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func NewConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "management config",
+	}
+	cmd.AddCommand(
+		NewPrintConfigCmd(),
+		NewInitConfigCmd(),
+	)
+	return cmd
+}
+
+func NewPrintConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "print",
+		Short: "Loads the configuration file, combines it with the default settings, and outputs the actual resulting configuration.",
+		Long:  `This command reads the given configuration file and merges it with the system's default settings. The final output displays the combined result which will be the actual configuration that gets applied.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+			path, err := flags.GetString("config")
+			cfg, _ := config.LoadFile(path)
+			if err != nil {
+				return err
+			}
+			cmd.Print(config.Marshal(cfg))
+			return nil
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringP("config", "c", "~/.mping.yml", "config path")
+	return cmd
+}
+
+func NewInitConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Generates initial settings.",
+		Long:  `This command generates the initial settings for the system or application.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cfg := config.DefaultConfig()
+			cmd.Print(config.Marshal(cfg))
+		},
+	}
+	return cmd
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,8 @@ import (
 	"github.com/servak/mping/internal/ui"
 )
 
+const DefaultICMPBody = "mping"
+
 type Config struct {
 	Prober map[string]*prober.ProberConfig `yaml:"prober"`
 	UI     *ui.UIConfig                    `yaml:"ui"`
@@ -26,11 +28,15 @@ func DefaultConfig() *Config {
 		Prober: map[string]*prober.ProberConfig{
 			string(prober.ICMPV4): {
 				Probe: prober.ICMPV4,
-				ICMP:  &prober.ICMPConfig{},
+				ICMP: &prober.ICMPConfig{
+					Body: DefaultICMPBody,
+				},
 			},
 			string(prober.ICMPV6): {
 				Probe: prober.ICMPV6,
-				ICMP:  &prober.ICMPConfig{},
+				ICMP: &prober.ICMPConfig{
+					Body: DefaultICMPBody,
+				},
 			},
 			string(prober.HTTP): {
 				Probe: prober.HTTP,
@@ -74,4 +80,9 @@ func LoadFile(path string) (*Config, error) {
 		return DefaultConfig(), err
 	}
 	return Load(string(out))
+}
+
+func Marshal(c *Config) string {
+	out, _ := yaml.Marshal(c)
+	return string(out)
 }

--- a/internal/prober/config.go
+++ b/internal/prober/config.go
@@ -10,8 +10,8 @@ import (
 type (
 	ProberConfig struct {
 		Probe ProbeType   `yaml:"probe"`
-		ICMP  *ICMPConfig `yaml:"icmp"`
-		HTTP  *HTTPConfig `yaml:"http"`
+		ICMP  *ICMPConfig `yaml:"icmp,omitempty"`
+		HTTP  *HTTPConfig `yaml:"http,omitempty"`
 	}
 )
 


### PR DESCRIPTION
This pull request presents a new command for managing configuration files. Along with this, two subcommands have been added:

- Display Current Settings: This subcommand outputs the current configuration settings, allowing users to understand the current state of the system at a glance.
- Display Default Settings: This subcommand outputs the default configuration settings, enabling users to compare current configurations with defaults and reset configurations if needed.

These improvements offer users a more intuitive and effective way to manage their configuration files. Further instructions on how to utilize these commands will be available in the project's user guide.