### PR TITLE
Fix GoReleaser CI and add rpm/deb package support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,17 @@
+version: 2
+
 project_name: mping
+
 env:
   - GO111MODULE=on
+
 before:
   hooks:
     - go mod tidy
+
 builds:
-  - main: ./cmd/mping/
+  - id: mping
+    main: ./cmd/mping/
     binary: mping
     ldflags:
       - -s -w
@@ -17,10 +23,13 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
+      - "386"
 
 archives:
-  - format: tar.gz
-    # this name template makes the OS and Arch compatible with the results of uname.
+  - id: mping-archive
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -28,17 +37,64 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
+    files:
+      - README.md
     format_overrides:
-    - goos: windows
-      format: zip
+      - goos: windows
+        format: zip
+
+# Linux packages
+nfpms:
+  - id: mping-packages
+    package_name: mping
+    vendor: Kakuya Ando
+    homepage: https://github.com/servak/mping
+    maintainer: Kakuya Ando <fservak@gmail.com>
+    description: |
+      Multi-target, multi-protocol network monitoring tool that extends traditional ping functionality.
+      Monitor multiple hosts and services simultaneously with real-time statistics and an interactive terminal UI.
+      Supports ICMP, HTTP/HTTPS, TCP, and DNS monitoring.
+    license: MIT
+    section: net
+    priority: optional
+    formats:
+      - deb
+      - rpm
+    dependencies:
+      - iproute2
+    bindir: /usr/local/bin
+    scripts:
+      postinstall: ./scripts/postinstall.sh
+    rpm:
+      group: Applications/Internet
+      summary: Multi-protocol network monitoring tool
+    deb:
+      fields:
+        Priority: optional
 
 release:
   prerelease: auto
+  name_template: "{{.ProjectName}} v{{.Version}}"
+  header: |
+    ## mping {{.Tag}} Release
+
+    Multi-target, multi-protocol network monitoring tool with DNS support.
 
 changelog:
   sort: asc
+  use: github
   filters:
     exclude:
       - '^docs:'
       - '^test:'
+      - '^ci:'
+      - '^chore:'
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    configure)
+        # Set the CAP_NET_RAW capability on the binary
+        if [ -f /usr/local/bin/mping ]; then
+            setcap 'cap_net_raw+p' /usr/local/bin/mping || {
+                echo "Warning: Failed to set cap_net_raw capability on /usr/local/bin/mping"
+                echo "The application may need to run as root for ICMP operations"
+                echo "To fix this manually, run: sudo setcap cap_net_raw=+ep /usr/local/bin/mping"
+                exit 0
+            }
+            echo "Successfully set cap_net_raw capability on mping"
+        else
+            echo "Warning: mping binary not found at /usr/local/bin/mping"
+        fi
+        ;;
+    *)
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
## Summary
- Fix GoReleaser CI configuration that wasn't working properly
- Update to GoReleaser v2 format with modern configuration
- Add Linux package support (rpm and deb) for multiple architectures
- Add post-install script for setting required capabilities

## Changes
- **Updated .goreleaser.yml**: Migrated to GoReleaser v2 format with integrated nfpm configuration
- **Package Support**: Added rpm/deb package creation for amd64, arm64, and 386 architectures
- **Post-install Script**: Added scripts/postinstall.sh to set cap_net_raw capability for ICMP operations
- **Build Configuration**: Enhanced build matrix with explicit architecture definitions
- **Release Configuration**: Added modern changelog grouping and release template

## Test plan
- [x] Local testing with `goreleaser release --snapshot --clean --skip=publish`
- [x] Verified creation of 6 Linux packages (3 architectures × 2 formats)
- [x] Verified creation of 8 archives for all supported platforms
- [ ] Test CI workflow execution on merge
- [ ] Verify package installation on Ubuntu/CentOS systems